### PR TITLE
Migrating from Travis CI to GitHub actions

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -1,0 +1,83 @@
+# Based on https://github.com/r-lib/actions/blob/master/examples/check-standard.yaml
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: windows-latest, r: 'release'}
+          - {os: macOS-latest, r: 'release'}
+          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      RSPM: ${{ matrix.config.rspm }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: ${{ matrix.config.r }}
+
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Restore R package cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          while read -r cmd
+          do
+            eval sudo $cmd
+          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+
+      - name: Install dependencies
+        run: |
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("rcmdcheck")
+        shell: Rscript {0}
+
+      - name: Check
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+        run: |
+          options(crayon.enabled = TRUE)
+          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+        shell: Rscript {0}
+
+      - name: Upload check results
+        if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+          path: check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
-
-language: R
-cache: packages
-after_success:
-  - Rscript -e 'covr::codecov()'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 `Distance`
 ==========
 
-[![Build Status](https://travis-ci.org/DistanceDevelopment/Distance.svg?branch=master)](https://travis-ci.org/DistanceDevelopment/Distance)
+[![Build Status](https://github.com/DistanceDevelopment/Distance/workflows/CI/badge.svg?branch=master)](https://github.com/DistanceDevelopment/Distance/actions?query=workflow%3ACI+branch%3Amaster)
 [![CRAN (RStudio Mirror) Downloads](http://cranlogs.r-pkg.org/badges/Distance)](https://www.r-pkg.org/pkg/Distance)
 [![CRAN Version](http://www.r-pkg.org/badges/version/Distance)](https://www.r-pkg.org/pkg/Distance)
  [![Codecov test coverage](https://codecov.io/gh/DistanceDevelopment/Distance/branch/master/graph/badge.svg)](https://codecov.io/gh/DistanceDevelopment/Distance?branch=master)


### PR DESCRIPTION
I have noticed that you have set up Travis CI for Distance some time ago, but it now wrongly shows builds as passing, despite errors: https://travis-ci.org/github/DistanceDevelopment/Distance. The Codecov integration does not seem to work any more too - https://app.codecov.io/gh/DistanceDevelopment/Distance says last commit was 10 month ago, while there were obviously newer commits.

In GAP, for https://github.com/gap-system/gap and many packages in https://github.com/gap-packages/, we migrated from Travis CI to GitHub actions after Travis Ci stopped to be free. I've found a collection of recipes at https://github.com/r-lib/actions seems useful, and this is the first step. You can see the results of the tests in my fork at https://github.com/alex-konovalov/Distance/actions and as soon as this is merged, you will be able to see results of the tests in the Actions tab above: https://github.com/DistanceDevelopment/Distance/actions. 

It now runs R CMD check in Linux, macOS and Windows. Tests pass with 0 errors, 0 warnings and 2 notes (see e.g. https://github.com/alex-konovalov/Distance/runs/2676747532?check_suite_focus=true and expand the "Check" section). If this looks good to you, I suggest to merge this to ensure that at least the CI is restored and operational, and all new changes are automatically checked, and then we could look at further setup e.g. fixing code coverage, and other useful tests that you can find in https://github.com/r-lib/actions/blob/master/examples/README.md.
