### PR TITLE
[WIP] Further CI fixes 

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,4 @@
 .DS_Store
-tests
 LICENSE
 ^\.travis\.yml$
 ^appveyor\.yml$

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -65,6 +65,7 @@ jobs:
         run: |
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
+          remotes::install_github("DistanceDevelopment/mrds")
         shell: Rscript {0}
 
       - name: Check

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,22 +1,25 @@
+# Based on https://github.com/r-lib/actions/blob/master/examples/check-standard.yaml
 on:
   push:
     branches:
-      - main
       - master
+      - main
   pull_request:
     branches:
-      - main
       - master
+      - main
 
 name: test-coverage
+
 
 jobs:
   test-coverage:
     runs-on: macOS-latest
-#    runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+  
     steps:
+    
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-r@v1
@@ -29,7 +32,7 @@ jobs:
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
-
+    
       - name: Restore R package cache
         uses: actions/cache@v2
         with:
@@ -37,30 +40,15 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
-#      - name: Install system dependencies
-#        run: |
-#          while read -r cmd
-#          do
-#            eval sudo $cmd
-#          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
-
       - name: Install dependencies
         run: |
           install.packages(c("remotes"))
           remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("covr", dependencies = TRUE)
+          remotes::install_cran("covr")
           remotes::install_github("DistanceDevelopment/mrds")
         shell: Rscript {0}
-
+      
       - name: Test coverage
-        run: |
-          library(covr)
-          cov <- covr::package_coverage(quiet = FALSE, clean = FALSE)
-          covr::codecov(cov, quiet=FALSE)
-          sessionInfo()
+        run: covr::codecov()
         shell: Rscript {0}
-
-      - name: Show debug output
-        if: always()
-        run: find /tmp/* -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
+  

--- a/tests/testthat/test_bootdht.R
+++ b/tests/testthat/test_bootdht.R
@@ -1,6 +1,9 @@
 context("Testing bootdht")
 
 test_that("area=0 with default summary",{
+
+  skip_on_cran()
+
   data(amakihi)
   # subset for testing speed
   amakihi <- amakihi[1:300,]


### PR DESCRIPTION
@dill @LHMarshall I've uncommented tests and installed mrds from GitHub - they now all pass! The log says it takes 97 sec (macOS build). Was the problem to run them on CRAN with runtime - or with tests stability?

https://cran.r-project.org/web/packages/testthat/vignettes/skipping.html says one can use various options to skip tests on CRAN, or on GitHub actions, or on a particular OS. If you can let me know which options to apply to which of the tests, I will be happy to put them into test files. Alternatively, I can update this PR to have only two first commits, and you can add these options to tests yourself. 
