### PR TITLE
Adjustment rewrite

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,8 @@ Distance 1.0.5
 * fix bootdht issue when cluster results were requests (#103)
 * improve flatfile documentation (thanks to Maggie Blake for pointing this out)
 * fixed bug in cutpoint calculations in create.bins (#108)
+* order argument to ds() is now only used to specify order, to fix a given number of adjustments use the new argument nadj (see ?ds for more info)
+* fix bug where polynomial adjustments started at the wrong order (2 rather than 4)
 
 Distance 1.0.4
 ----------------------

--- a/R/ds.R
+++ b/R/ds.R
@@ -434,9 +434,9 @@ ds <- function(data, truncation=ifelse(is.null(cutpoints),
     aic.search <- FALSE
     if(!is.null(order)){
 
-      # if both are supplied
+      # if both nadj and order are supplied
       if(!is.null(nadj)){
-        warning("order and nadj supplied, ignoring nadj")
+        if(length(order) != nadj) stop("The number of adjustment orders specified in 'order' must match 'nadj'")
       }
 
       if(any(order != ceiling(order))){
@@ -448,7 +448,6 @@ ds <- function(data, truncation=ifelse(is.null(cutpoints),
     }else if(!is.null(nadj)){
       order <- get_adj_orders(nadj, key, adjustment)
     }else{
-
       # if there are covariates then don't do the AIC search
       if(formula != ~1){
         aic.search <- FALSE
@@ -456,7 +455,6 @@ ds <- function(data, truncation=ifelse(is.null(cutpoints),
       }else{
       # otherwise go ahead and set up the candidate adjustment orders
         aic.search <- TRUE
-
         order <- get_adj_orders(max_adjustments, key, adjustment)
       }
     }

--- a/R/ds.R
+++ b/R/ds.R
@@ -457,18 +457,7 @@ ds <- function(data, truncation=ifelse(is.null(cutpoints),
       }
 
     }else if(!is.null(nadj)){
-      # this is according to p. 47 of IDS.
-      if(adjustment %in% c("poly", "herm")){
-        # simple and Hermite polynomials
-        order <- seq(4, by=2, length.out=nadj)
-      }else if(adjustment=="cos" & key=="unif"){
-        # Fourier
-        order <- 1:nadj
-      }else{
-        # cosine
-        order <- seq(2, by=1, length.out=nadj)
-      }
-
+      order <- get_adj_orders(nadj, key, adjustment)
     }else{
 
       # if there are covariates then don't do the AIC search
@@ -479,19 +468,7 @@ ds <- function(data, truncation=ifelse(is.null(cutpoints),
       # otherwise go ahead and set up the candidate adjustment orders
         aic.search <- TRUE
 
-        # this is according to p. 47 of IDS
-        if(key=="unif" & adjustment=="cos"){
-          # for Fourier...
-          order <- 1:max_adjustments
-        }else if(adjustment %in% c("poly", "herm")){
-          # simple and Hermite poly: even from 4
-          order <- seq(4, by=2, length.out=max_adjustments)
-        }else if(adjustment=="cos"){
-          # cosine: by 1 from 2
-          order <- seq(2, by=1, length.out=max_adjustments)
-        }else{
-          stop("Bad adjustment term definition")
-        }
+        order <- get_adj_orders(max_adjustments, key, adjustment)
       }
     }
 

--- a/R/ds.R
+++ b/R/ds.R
@@ -443,18 +443,7 @@ ds <- function(data, truncation=ifelse(is.null(cutpoints),
           stop("Adjustment orders must be integers.")
       }
 
-      # check for each adjustment type
       order <- sort(order)
-      if(adjustment=="poly"){
-        if(any(order/2 != ceiling(order/2))){
-          stop("Adjustment orders must be even for simple polynomials.")
-        }
-      }
-      if((adjustment=="herm" | adjustment=="cos") & key!="unif"){
-        if(any(order==1)){
-          stop("Adjustment orders for Hermite polynomials and cosines must start at 2.")
-        }
-      }
 
     }else if(!is.null(nadj)){
       order <- get_adj_orders(nadj, key, adjustment)

--- a/R/get_adj_orders.R
+++ b/R/get_adj_orders.R
@@ -1,0 +1,21 @@
+# generate the appropriate orders for adjustments
+get_adj_orders <- function(n, key, adjustment){
+
+  # this is according to p. 47 of IDS
+  if(key=="unif" & adjustment=="cos"){
+    # for Fourier...
+    order <- 1:n
+  }else if(adjustment %in% c("poly", "herm")){
+    # simple and Hermite poly: even from 4 (unless uniform)
+    starto <- 4
+    if(key == "unif") starto <- 2
+    order <- seq(starto, by=2, length.out=n)
+  }else if(adjustment=="cos"){
+    # cosine: by 1 from 2
+    order <- seq(2, by=1, length.out=n)
+  }else{
+    stop("Bad adjustment term definition")
+  }
+
+  return(order)
+}

--- a/man/ds.Rd
+++ b/man/ds.Rd
@@ -13,6 +13,7 @@ ds(
   formula = ~1,
   key = c("hn", "hr", "unif"),
   adjustment = c("cos", "herm", "poly"),
+  nadj = NULL,
   order = NULL,
   scale = c("width", "scale"),
   cutpoints = NULL,
@@ -70,16 +71,24 @@ used, covariates cannot be included in the model.}
 \code{"herm"} gives Hermite polynomial and \code{"poly"} gives simple polynomial. A
 value of \code{NULL} indicates that no adjustments are to be fitted.}
 
-\item{order}{orders of the adjustment terms to fit (as a vector/scalar).
-The default value (\code{NULL}) will select via AIC up to \code{max_adjustments}
-adjustments. If a single number is given, that number is expanded to be
-\code{seq(term.min, order, by=1)} where \code{term.min} is the appropriate minimum
-order for this type of adjustment  (1 for cosine, 2 for simple and Hermite
-polynomial).   For simple and Hermite polynomials, the values generated
-then are multipled by 2 to give the order used by the fitting routine -
-for example, specifying 3 for a simple or Hermite polynomial series would
-give adjustments of order \code{c(2, 3) * 2 = 4} and \code{6}.
-See Buckland et al. 2001 for more details on adjustment term specification.}
+\item{nadj}{the number of adjustment terms to fit. The default value
+(\code{NULL}) will select via AIC (using a sequential forward selection
+algorithm) up to \code{max.adjustment} adjustments (unless \code{order} is specified).
+A non-negative integer value will cause the specified number of adjustments
+to be fitted. The order of adjustment terms used will depend on the \code{key}
+and \code{adjustment}. For \code{key="unif"}, adjustments of order 1, 2, 3, ... are
+fitted when \code{adjustment = "cos"} and order 2, 4, 6, ... otherwise. For
+\code{key="hn"} or \code{"hr"} adjustments of order 2, 3, 4, ... are fitted when
+\code{adjustment = "cos"} and order 4, 6, 8, ... otherwise. See Buckland et al.
+(2001, p. 47) for details.}
+
+\item{order}{order of adjustment terms to fit. The default value (\code{NULL})
+results in \code{ds} choosing the orders to use - see \code{nadj}. Otherwise a scalar
+positive integer value can be used to fit a single adjustment term of the
+specified order, and a vector of positive integers to fit multiple
+adjustment terms of the specified orders. For simple and Hermite polynomial
+adjustments, only even orders are allowed. The number of adjustment terms
+specified here must match \code{nadj} (or \code{nadj} can be the default \code{NULL} value).}
 
 \item{scale}{the scale by which the distances in the adjustment terms are
 divided. Defaults to \code{"width"}, scaling by the truncation distance. If the

--- a/tests/testthat/test_adjustments.R
+++ b/tests/testthat/test_adjustments.R
@@ -1,0 +1,130 @@
+# test ds()
+
+par.tol <- 1e-5
+N.tol <- 1e-3
+lnl.tol <- 1e-4
+
+context("Adjustment terms")
+
+# data setup
+data(book.tee.data)
+egdata <- book.tee.data$book.tee.dataframe
+egdata <- egdata[!duplicated(egdata$object),]
+
+
+test_that("adjustments expand correctly",{
+  skip_on_cran()
+
+  egdata <- egdata[egdata$observer==1,]
+
+  # hn + cos(2)
+  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="hn",
+                                           nadj=1))$ddf$name.message),
+               "half-normal key function with cosine(2) adjustments")
+
+  # hn + cos(2,3,4,5)
+  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="hn",
+                                           nadj=4))$ddf$name.message),
+               "half-normal key function with cosine(2,3,4,5) adjustments")
+
+  #unif + cos(1,2)
+  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="unif",
+                                           nadj=2))$ddf$name.message),
+               "uniform key function with cosine(1,2) adjustments")
+
+  #unif + poly(2)
+  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="unif",
+                                           adjustment="poly",
+                                           nadj=1))$ddf$name.message),
+               "uniform key function with simple polynomial(2) adjustments")
+
+  #unif + herm(2)
+  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="unif",
+                                           adjustment="herm",
+                                           nadj=1))$ddf$name.message),
+               "uniform key function with Hermite(2) adjustments")
+
+  # hn + cos(2,3)
+  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="hn",
+                                           order=2:3))$ddf$name.message),
+               "half-normal key function with cosine(2,3) adjustments")
+})
+
+test_that("adjustments orders start correctly",{
+  skip_on_cran()
+
+  # hn+poly starts at 4
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hn", adj="poly")),
+                 "Fitting half-normal key function with simple polynomial\\(4\\) adjustments")
+  # hn+cos starts at 2
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hn", adj="cos")),
+                 "Fitting half-normal key function with cosine\\(2\\) adjustments")
+  # hn+herm starts at 4
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hn", adj="herm")),
+                 "Fitting half-normal key function with Hermite\\(4\\) adjustments")
+
+  # hr+poly starts at 4
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hr", adj="poly")),
+                 "Fitting hazard-rate key function with simple polynomial\\(4\\) adjustments")
+  # hr+cos starts at 2
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hr", adj="cos")),
+                 "Fitting hazard-rate key function with cosine\\(2\\) adjustments")
+  # hr+herm starts at 4
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hr", adj="herm")),
+                 "Fitting hazard-rate key function with Hermite\\(4\\) adjustments")
+
+  # unif+poly starts at 2
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="unif",
+                                     adj="poly", max_adjustments=1)),
+                 "Fitting uniform key function with simple polynomial\\(2\\) adjustments")
+  # unif+cos starts at 1
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="unif",
+                                     adj="cos", max_adjustments=1)),
+                 "Fitting uniform key function with cosine\\(1\\) adjustments")
+  # unif+herm starts at 2
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="unif",
+                                     adj="herm", max_adjustments=1)),
+                 "Fitting uniform key function with Hermite\\(2\\) adjustments")
+
+})
+
+# max adjustments arg
+test_that("max.adjustments works",{
+  skip_on_cran()
+
+  egdata <- egdata[egdata$observer==1,]
+
+  # setting max.adjustments=0 gives no adjustments
+  expect_equal(summary(ds(egdata, 4, key="hn", max_adjustments=0,
+                          adjustment="cos"))$ddf$name.message,
+               "half-normal key function")
+
+  # some delicious stake
+  data(stake77)
+  dists <- stake77$PD[stake77$Obs2==1]
+  dists <- c(dists, dists[dists>10])
+  dists <- c(dists, dists[dists<5])
+  dists <- c(dists, dists[dists<5])
+
+  # ignore warnings below from monotonicity checks, don't care about that here
+  expect_equal(summary(suppressWarnings(
+                ds(dists, 20, key="hn", max_adjustments=3,
+                   adjustment="cos")))$ddf$name.message,
+               "half-normal key function with cosine(2,3,4) adjustments")
+
+  expect_equal(summary(suppressWarnings(
+                ds(dists, 20, key="hn", max_adjustments=2,
+                   adjustment="cos")))$ddf$name.message,
+               "half-normal key function with cosine(2,3) adjustments")
+
+  expect_equal(summary(suppressWarnings(
+                ds(dists, 20, key="hn", max_adjustments=1,
+                   adjustment="cos")))$ddf$name.message,
+               "half-normal key function with cosine(2) adjustments")
+
+  expect_equal(summary(suppressWarnings(
+                ds(dists, 20, key="hn", max_adjustments=6,
+                   adjustment="cos")))$ddf$name.message,
+               "half-normal key function with cosine(2,3,4) adjustments")
+})
+

--- a/tests/testthat/test_adjustments.R
+++ b/tests/testthat/test_adjustments.R
@@ -128,3 +128,13 @@ test_that("max.adjustments works",{
                "half-normal key function with cosine(2,3,4) adjustments")
 })
 
+test_that("errors thrown",{
+
+  egdata <- egdata[egdata$observer==1,]
+
+  # nadj and length(order) don't match
+  expect_error(suppressWarnings(summary(ds(egdata, 4, key="hn", order=c(2,3),
+                                           nadj=1))$ddf$name.message),
+               "The number of adjustment orders specified in 'order' must match 'nadj'")
+
+})

--- a/tests/testthat/test_dht.R
+++ b/tests/testthat/test_dht.R
@@ -64,6 +64,6 @@ test_that("no Area column works", {
   # totals line doesn't match here as the proportion of effort between
   # strata is different
   expect_equal(minke_with_Area$dht$individuals$D[1:2,],
-               minke_no_Area$dht$individuals$D[1:2,])
+               minke_no_Area$dht$individuals$D[1:2,], tol=1e-6)
 
 })

--- a/tests/testthat/test_ds.R
+++ b/tests/testthat/test_ds.R
@@ -210,6 +210,40 @@ test_that("adjustments expand correctly",{
   expect_equal(suppressWarnings(summary(ds(egdata, 4, key="unif",
                                            order=2))$ddf$name.message),
                "uniform key function with cosine(1,2) adjustments")
+})
+
+test_that("adjustments orders start correctly",{
+  skip_on_cran()
+
+  # hn+poly starts at 4
+  expect_message(ds(egdata, trunc = 4, key = "hn", adj = "poly"),
+                 "Fitting half-normal key function with simple polynomial\\(4\\) adjustments")
+  # hn+cos starts at 2
+  expect_message(ds(egdata, trunc = 4, key = "hn", adj = "cos"),
+                 "Fitting half-normal key function with cosine\\(2\\) adjustments")
+  # hn+herm starts at 4
+  expect_message(ds(egdata, trunc = 4, key = "hn", adj = "herm"),
+                 "Fitting half-normal key function with Hermite\\(4\\) adjustments")
+
+  # hr+poly starts at 4
+  expect_message(ds(egdata, trunc = 4, key = "hr", adj = "poly"),
+                 "Fitting hazard-rate key function with simple polynomial\\(4\\) adjustments")
+  # hr+cos starts at 2
+  expect_message(ds(egdata, trunc = 4, key = "hr", adj = "cos"),
+                 "Fitting hazard-rate key function with cosine\\(2\\) adjustments")
+  # hr+herm starts at 4
+  expect_message(ds(egdata, trunc = 4, key = "hr", adj = "herm"),
+                 "Fitting hazard-rate key function with Hermite\\(4\\) adjustments")
+
+  # unif+poly starts at 4
+  expect_message(ds(egdata, trunc = 4, key = "unif", adj = "poly"),
+                 "Fitting uniform key function with simple polynomial\\(4\\) adjustments")
+  # unif+cos starts at 2
+  expect_message(ds(egdata, trunc = 4, key = "unif", adj = "cos"),
+                 "Fitting uniform key function with cosine\\(1\\) adjustments")
+  # unif+herm starts at 4
+  expect_message(ds(egdata, trunc = 4, key = "unif", adj = "herm"),
+                 "Fitting uniform key function with Hermite\\(4\\) adjustments")
 
 })
 
@@ -225,7 +259,6 @@ test_that("Percentage truncation works when distances are missing",{
 
 
 # just distend and distbegin can be supplied
-
 test_that("just distend and distbegin can be supplied", {
   # make some data
   bin.data <- create_bins(egdata, c(0, 1, 2, 3, 4))
@@ -276,7 +309,6 @@ test_that("max.adjustments works",{
 })
 
 # warnings when bad models get fitted
-
 test_that("warnings of bad models get thrown",{
   skip_on_cran()
 

--- a/tests/testthat/test_ds.R
+++ b/tests/testthat/test_ds.R
@@ -206,6 +206,12 @@ test_that("adjustments expand correctly",{
                                            nadj=2))$ddf$name.message),
                "uniform key function with cosine(1,2) adjustments")
 
+  #unif + poly(2)
+  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="unif",
+                                           adjustment="poly",
+                                           nadj=1))$ddf$name.message),
+               "uniform key function with simple polynomial(2) adjustments")
+
   # hn + cos(2,3)
   expect_equal(suppressWarnings(summary(ds(egdata, 4, key="hn",
                                            order=2:3))$ddf$name.message),

--- a/tests/testthat/test_ds.R
+++ b/tests/testthat/test_ds.R
@@ -193,56 +193,56 @@ test_that("adjustments expand correctly",{
 
   # hn + cos(2)
   expect_equal(suppressWarnings(summary(ds(egdata, 4, key="hn",
-                                           order=2))$ddf$name.message),
+                                           nadj=1))$ddf$name.message),
                "half-normal key function with cosine(2) adjustments")
+
+  # hn + cos(2,3,4,5)
+  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="hn",
+                                           nadj=4))$ddf$name.message),
+               "half-normal key function with cosine(2,3,4,5) adjustments")
+
+  #unif + cos(1,2)
+  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="unif",
+                                           nadj=2))$ddf$name.message),
+               "uniform key function with cosine(1,2) adjustments")
 
   # hn + cos(2,3)
   expect_equal(suppressWarnings(summary(ds(egdata, 4, key="hn",
                                            order=2:3))$ddf$name.message),
                "half-normal key function with cosine(2,3) adjustments")
-
-  # hn + cos(2,3,4,5)
-  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="hn",
-                                           order=5))$ddf$name.message),
-               "half-normal key function with cosine(2,3,4,5) adjustments")
-
-  #unif + cos(1,2)
-  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="unif",
-                                           order=2))$ddf$name.message),
-               "uniform key function with cosine(1,2) adjustments")
 })
 
 test_that("adjustments orders start correctly",{
   skip_on_cran()
 
   # hn+poly starts at 4
-  expect_message(ds(egdata, trunc = 4, key = "hn", adj = "poly"),
+  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "hn", adj = "poly")),
                  "Fitting half-normal key function with simple polynomial\\(4\\) adjustments")
   # hn+cos starts at 2
-  expect_message(ds(egdata, trunc = 4, key = "hn", adj = "cos"),
+  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "hn", adj = "cos")),
                  "Fitting half-normal key function with cosine\\(2\\) adjustments")
   # hn+herm starts at 4
-  expect_message(ds(egdata, trunc = 4, key = "hn", adj = "herm"),
+  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "hn", adj = "herm")),
                  "Fitting half-normal key function with Hermite\\(4\\) adjustments")
 
   # hr+poly starts at 4
-  expect_message(ds(egdata, trunc = 4, key = "hr", adj = "poly"),
+  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "hr", adj = "poly")),
                  "Fitting hazard-rate key function with simple polynomial\\(4\\) adjustments")
   # hr+cos starts at 2
-  expect_message(ds(egdata, trunc = 4, key = "hr", adj = "cos"),
+  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "hr", adj = "cos")),
                  "Fitting hazard-rate key function with cosine\\(2\\) adjustments")
   # hr+herm starts at 4
-  expect_message(ds(egdata, trunc = 4, key = "hr", adj = "herm"),
+  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "hr", adj = "herm")),
                  "Fitting hazard-rate key function with Hermite\\(4\\) adjustments")
 
   # unif+poly starts at 4
-  expect_message(ds(egdata, trunc = 4, key = "unif", adj = "poly"),
+  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "unif", adj = "poly")),
                  "Fitting uniform key function with simple polynomial\\(4\\) adjustments")
   # unif+cos starts at 2
-  expect_message(ds(egdata, trunc = 4, key = "unif", adj = "cos"),
+  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "unif", adj = "cos")),
                  "Fitting uniform key function with cosine\\(1\\) adjustments")
   # unif+herm starts at 4
-  expect_message(ds(egdata, trunc = 4, key = "unif", adj = "herm"),
+  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "unif", adj = "herm")),
                  "Fitting uniform key function with Hermite\\(4\\) adjustments")
 
 })

--- a/tests/testthat/test_ds.R
+++ b/tests/testthat/test_ds.R
@@ -212,6 +212,12 @@ test_that("adjustments expand correctly",{
                                            nadj=1))$ddf$name.message),
                "uniform key function with simple polynomial(2) adjustments")
 
+  #unif + herm(2)
+  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="unif",
+                                           adjustment="herm",
+                                           nadj=1))$ddf$name.message),
+               "uniform key function with Hermite(2) adjustments")
+
   # hn + cos(2,3)
   expect_equal(suppressWarnings(summary(ds(egdata, 4, key="hn",
                                            order=2:3))$ddf$name.message),
@@ -222,34 +228,37 @@ test_that("adjustments orders start correctly",{
   skip_on_cran()
 
   # hn+poly starts at 4
-  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "hn", adj = "poly")),
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hn", adj="poly")),
                  "Fitting half-normal key function with simple polynomial\\(4\\) adjustments")
   # hn+cos starts at 2
-  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "hn", adj = "cos")),
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hn", adj="cos")),
                  "Fitting half-normal key function with cosine\\(2\\) adjustments")
   # hn+herm starts at 4
-  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "hn", adj = "herm")),
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hn", adj="herm")),
                  "Fitting half-normal key function with Hermite\\(4\\) adjustments")
 
   # hr+poly starts at 4
-  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "hr", adj = "poly")),
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hr", adj="poly")),
                  "Fitting hazard-rate key function with simple polynomial\\(4\\) adjustments")
   # hr+cos starts at 2
-  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "hr", adj = "cos")),
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hr", adj="cos")),
                  "Fitting hazard-rate key function with cosine\\(2\\) adjustments")
   # hr+herm starts at 4
-  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "hr", adj = "herm")),
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hr", adj="herm")),
                  "Fitting hazard-rate key function with Hermite\\(4\\) adjustments")
 
-  # unif+poly starts at 4
-  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "unif", adj = "poly")),
-                 "Fitting uniform key function with simple polynomial\\(4\\) adjustments")
-  # unif+cos starts at 2
-  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "unif", adj = "cos")),
+  # unif+poly starts at 2
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="unif",
+                                     adj="poly", max_adjustments=1)),
+                 "Fitting uniform key function with simple polynomial\\(2\\) adjustments")
+  # unif+cos starts at 1
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="unif",
+                                     adj="cos", max_adjustments=1)),
                  "Fitting uniform key function with cosine\\(1\\) adjustments")
-  # unif+herm starts at 4
-  expect_message(suppressWarnings(ds(egdata, trunc = 4, key = "unif", adj = "herm")),
-                 "Fitting uniform key function with Hermite\\(4\\) adjustments")
+  # unif+herm starts at 2
+  expect_message(suppressWarnings(ds(egdata, trunc=4, key="unif",
+                                     adj="herm", max_adjustments=1)),
+                 "Fitting uniform key function with Hermite\\(2\\) adjustments")
 
 })
 

--- a/tests/testthat/test_ds.R
+++ b/tests/testthat/test_ds.R
@@ -186,82 +186,6 @@ test_that("Truncation is handled",{
 
 })
 
-test_that("adjustments expand correctly",{
-  skip_on_cran()
-
-  egdata <- egdata[egdata$observer==1,]
-
-  # hn + cos(2)
-  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="hn",
-                                           nadj=1))$ddf$name.message),
-               "half-normal key function with cosine(2) adjustments")
-
-  # hn + cos(2,3,4,5)
-  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="hn",
-                                           nadj=4))$ddf$name.message),
-               "half-normal key function with cosine(2,3,4,5) adjustments")
-
-  #unif + cos(1,2)
-  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="unif",
-                                           nadj=2))$ddf$name.message),
-               "uniform key function with cosine(1,2) adjustments")
-
-  #unif + poly(2)
-  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="unif",
-                                           adjustment="poly",
-                                           nadj=1))$ddf$name.message),
-               "uniform key function with simple polynomial(2) adjustments")
-
-  #unif + herm(2)
-  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="unif",
-                                           adjustment="herm",
-                                           nadj=1))$ddf$name.message),
-               "uniform key function with Hermite(2) adjustments")
-
-  # hn + cos(2,3)
-  expect_equal(suppressWarnings(summary(ds(egdata, 4, key="hn",
-                                           order=2:3))$ddf$name.message),
-               "half-normal key function with cosine(2,3) adjustments")
-})
-
-test_that("adjustments orders start correctly",{
-  skip_on_cran()
-
-  # hn+poly starts at 4
-  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hn", adj="poly")),
-                 "Fitting half-normal key function with simple polynomial\\(4\\) adjustments")
-  # hn+cos starts at 2
-  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hn", adj="cos")),
-                 "Fitting half-normal key function with cosine\\(2\\) adjustments")
-  # hn+herm starts at 4
-  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hn", adj="herm")),
-                 "Fitting half-normal key function with Hermite\\(4\\) adjustments")
-
-  # hr+poly starts at 4
-  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hr", adj="poly")),
-                 "Fitting hazard-rate key function with simple polynomial\\(4\\) adjustments")
-  # hr+cos starts at 2
-  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hr", adj="cos")),
-                 "Fitting hazard-rate key function with cosine\\(2\\) adjustments")
-  # hr+herm starts at 4
-  expect_message(suppressWarnings(ds(egdata, trunc=4, key="hr", adj="herm")),
-                 "Fitting hazard-rate key function with Hermite\\(4\\) adjustments")
-
-  # unif+poly starts at 2
-  expect_message(suppressWarnings(ds(egdata, trunc=4, key="unif",
-                                     adj="poly", max_adjustments=1)),
-                 "Fitting uniform key function with simple polynomial\\(2\\) adjustments")
-  # unif+cos starts at 1
-  expect_message(suppressWarnings(ds(egdata, trunc=4, key="unif",
-                                     adj="cos", max_adjustments=1)),
-                 "Fitting uniform key function with cosine\\(1\\) adjustments")
-  # unif+herm starts at 2
-  expect_message(suppressWarnings(ds(egdata, trunc=4, key="unif",
-                                     adj="herm", max_adjustments=1)),
-                 "Fitting uniform key function with Hermite\\(2\\) adjustments")
-
-})
-
 # reported by Len Thomas 20 August
 test_that("Percentage truncation works when distances are missing",{
   skip_on_cran()
@@ -281,46 +205,6 @@ test_that("just distend and distbegin can be supplied", {
   expect_message(ds.model <- ds(bin.data, 4, monotonicity=FALSE, key="hn",
                                 adjustment=NULL),
                  "^Columns \"distbegin\" and \"distend\" in data: performing a binned analysis....*")
-})
-
-# max adjustments arg
-test_that("max.adjustments works",{
-  skip_on_cran()
-
-  egdata <- egdata[egdata$observer==1,]
-
-  # setting max.adjustments=0 gives no adjustments
-  expect_equal(summary(ds(egdata, 4, key="hn", max_adjustments=0,
-                          adjustment="cos"))$ddf$name.message,
-               "half-normal key function")
-
-  # some delicious stake
-  data(stake77)
-  dists <- stake77$PD[stake77$Obs2==1]
-  dists <- c(dists, dists[dists>10])
-  dists <- c(dists, dists[dists<5])
-  dists <- c(dists, dists[dists<5])
-
-  # ignore warnings below from monotonicity checks, don't care about that here
-  expect_equal(summary(suppressWarnings(
-                ds(dists, 20, key="hn", max_adjustments=3,
-                   adjustment="cos")))$ddf$name.message,
-               "half-normal key function with cosine(2,3,4) adjustments")
-
-  expect_equal(summary(suppressWarnings(
-                ds(dists, 20, key="hn", max_adjustments=2,
-                   adjustment="cos")))$ddf$name.message,
-               "half-normal key function with cosine(2,3) adjustments")
-
-  expect_equal(summary(suppressWarnings(
-                ds(dists, 20, key="hn", max_adjustments=1,
-                   adjustment="cos")))$ddf$name.message,
-               "half-normal key function with cosine(2) adjustments")
-
-  expect_equal(summary(suppressWarnings(
-                ds(dists, 20, key="hn", max_adjustments=6,
-                   adjustment="cos")))$ddf$name.message,
-               "half-normal key function with cosine(2,3,4) adjustments")
 })
 
 # warnings when bad models get fitted

--- a/tests/testthat/test_summarize.R
+++ b/tests/testthat/test_summarize.R
@@ -20,7 +20,7 @@ test_that("Error on different truncation distance", {
   t14 <- suppressWarnings(ds(egdata, list(left=1, right=4)))
 
   # when things are okay!
-  out <- "           Model                                       Key function Formula\n1   \\\\texttt{t4}                                        Half-normal      ~1\n2  \\\\texttt{t42}                                        Half-normal      ~1\n3 \\\\texttt{t4hr} Hazard-rate with cosine adjustment term of order 2      ~1\n  C-vM p-value $\\\\hat{P_a}$ se($\\\\hat{P_a}$) $\\\\Delta$AIC\n1    0.7789695    0.5842744       0.04637627     0.000000\n2    0.7789695    0.5842744       0.04637627     0.000000\n3    0.8170780    0.5556728       0.07197556     2.501712"
+  out <- "           Model                                       Key function Formula\n1   \\\\texttt{t4}                                        Half-normal      ~1\n2  \\\\texttt{t42}                                        Half-normal      ~1\n3 \\\\texttt{t4hr} Hazard-rate with cosine adjustment term of order 2      ~1\n  C-vM p-value $\\\\hat{P_a}$ se($\\\\hat{P_a}$) $\\\\Delta$AIC\n1    0.7789695    0.5842744       0.04637627     0.000000\n2    0.7789695    0.5842744       0.04637627     0.000000\n3    0.8170780    0.5556728       0.07197555     2.501712"
   expect_output(print(summarize_ds_models(t4, t42, t4hr)), out, fixed=TRUE)
 
   # right truncation different
@@ -41,7 +41,7 @@ test_that("Binning",{
   cp2 <- suppressMessages(ds(egdata, key="hn", order=0,
                   cutpoints=c(0, 2, 3, 3.84)))
 
-  out <- "           Model Key function Formula $\\\\chi^2$ $p$-value $\\\\hat{P_a}$\n1  \\\\texttt{cp1}  Half-normal      ~1           0.8980817    0.6287014\n2 \\\\texttt{cp11}  Half-normal      ~1           0.8980817    0.6287014\n  se($\\\\hat{P_a}$) $\\\\Delta$AIC\n1       0.05262632            0\n2       0.05262632            0"
+  out <- "           Model Key function Formula $\\\\chi^2$ $p$-value $\\\\hat{P_a}$\n1  \\\\texttt{cp1}  Half-normal      ~1           0.8980817    0.6287014\n2 \\\\texttt{cp11}  Half-normal      ~1           0.8980817    0.6287014\n  se($\\\\hat{P_a}$) $\\\\Delta$AIC\n1       0.05262633            0\n2       0.05262633            0"
   expect_output(print(summarize_ds_models(cp1, cp11)), out, fixed=TRUE)
 
   # different bins

--- a/tests/testthat/test_summarize.R
+++ b/tests/testthat/test_summarize.R
@@ -20,7 +20,7 @@ test_that("Error on different truncation distance", {
   t14 <- suppressWarnings(ds(egdata, list(left=1, right=4)))
 
   # when things are okay!
-  out <- "           Model                                       Key function Formula\n1   \\\\texttt{t4}                                        Half-normal      ~1\n2  \\\\texttt{t42}                                        Half-normal      ~1\n3 \\\\texttt{t4hr} Hazard-rate with cosine adjustment term of order 2      ~1\n  C-vM p-value $\\\\hat{P_a}$ se($\\\\hat{P_a}$) $\\\\Delta$AIC\n1    0.7789695    0.5842744       0.04637627     0.000000\n2    0.7789695    0.5842744       0.04637627     0.000000\n3    0.8170780    0.5556728       0.07197555     2.501712"
+  out <- "           Model                                       Key function Formula\n1   \\\\texttt{t4}                                        Half-normal      ~1\n2  \\\\texttt{t42}                                        Half-normal      ~1\n3 \\\\texttt{t4hr} Hazard-rate with cosine adjustment term of order 2      ~1\n  C-vM p-value $\\\\hat{P_a}$ se($\\\\hat{P_a}$) $\\\\Delta$AIC\n1    0.7789695    0.5842744       0.04637627     0.000000\n2    0.7789695    0.5842744       0.04637627     0.000000\n3    0.8170780    0.5556728       0.07197556     2.501712"
   expect_output(print(summarize_ds_models(t4, t42, t4hr)), out, fixed=TRUE)
 
   # right truncation different
@@ -41,7 +41,7 @@ test_that("Binning",{
   cp2 <- suppressMessages(ds(egdata, key="hn", order=0,
                   cutpoints=c(0, 2, 3, 3.84)))
 
-  out <- "           Model Key function Formula $\\\\chi^2$ $p$-value $\\\\hat{P_a}$\n1  \\\\texttt{cp1}  Half-normal      ~1           0.8980817    0.6287014\n2 \\\\texttt{cp11}  Half-normal      ~1           0.8980817    0.6287014\n  se($\\\\hat{P_a}$) $\\\\Delta$AIC\n1       0.05262633            0\n2       0.05262633            0"
+  out <- "           Model Key function Formula $\\\\chi^2$ $p$-value $\\\\hat{P_a}$\n1  \\\\texttt{cp1}  Half-normal      ~1           0.8980817    0.6287014\n2 \\\\texttt{cp11}  Half-normal      ~1           0.8980817    0.6287014\n  se($\\\\hat{P_a}$) $\\\\Delta$AIC\n1       0.05262632            0\n2       0.05262632            0"
   expect_output(print(summarize_ds_models(cp1, cp11)), out, fixed=TRUE)
 
   # different bins


### PR DESCRIPTION
* order argument to ds() is now only used to specify order, to fix a given number of adjustments use the new argument nadj (see ?ds for more info)
* fix bug where polynomial adjustments started at the wrong order (2 rather than 4)


based on #115 and #117 